### PR TITLE
jamcraft: an abomination that allows you to render HTML in Minecraft

### DIFF
--- a/jamcraft/.gitignore
+++ b/jamcraft/.gitignore
@@ -1,0 +1,5 @@
+.gradle
+.idea
+.kotlin
+run
+build

--- a/jamcraft/LICENSE.txt
+++ b/jamcraft/LICENSE.txt
@@ -1,0 +1,2 @@
+Copyright (c) 2024 
+All rights reserved.

--- a/jamcraft/build.gradle.kts
+++ b/jamcraft/build.gradle.kts
@@ -1,0 +1,110 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin("jvm") version "2.0.20"
+    id("fabric-loom") version "1.7.1"
+    id("maven-publish")
+}
+
+version = project.property("mod_version") as String
+group = project.property("maven_group") as String
+
+base {
+    archivesName.set(project.property("archives_base_name") as String)
+}
+
+val targetJavaVersion = 21
+java {
+    toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
+    // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+    // if it is present.
+    // If you remove this line, sources will not be generated.
+    withSourcesJar()
+}
+
+loom {
+    splitEnvironmentSourceSets()
+
+    mods {
+        register("jamcraft") {
+            sourceSet("main")
+            sourceSet("client")
+        }
+    }
+}
+
+repositories {
+    // Add repositories to retrieve artifacts from in here.
+    // You should only use this when depending on other mods because
+    // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
+    // See https://docs.gradle.org/current/userguide/declaring_repositories.html
+    // for more information about repositories.
+    mavenCentral()
+}
+
+dependencies {
+    // To change the versions see the gradle.properties file
+    minecraft("com.mojang:minecraft:${project.property("minecraft_version")}")
+    mappings("net.fabricmc:yarn:${project.property("yarn_mappings")}:v2")
+    modImplementation("net.fabricmc:fabric-loader:${project.property("loader_version")}")
+    modImplementation("net.fabricmc:fabric-language-kotlin:${project.property("kotlin_loader_version")}")
+
+    // Fabric API. This is technically optional, but you probably want it anyway.
+    modImplementation("net.fabricmc.fabric-api:fabric-api:${project.property("fabric_version")}")
+
+    implementation("org.jsoup:jsoup:1.18.1")
+}
+
+tasks.processResources {
+    inputs.property("version", project.version)
+    inputs.property("minecraft_version", project.property("minecraft_version"))
+    inputs.property("loader_version", project.property("loader_version"))
+    filteringCharset = "UTF-8"
+
+    filesMatching("fabric.mod.json") {
+        expand(
+            "version" to project.version,
+            "minecraft_version" to project.property("minecraft_version"),
+            "loader_version" to project.property("loader_version"),
+            "kotlin_loader_version" to project.property("kotlin_loader_version")
+        )
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    // ensure that the encoding is set to UTF-8, no matter what the system default is
+    // this fixes some edge cases with special characters not displaying correctly
+    // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
+    // If Javadoc is generated, this must be specified in that task too.
+    options.encoding = "UTF-8"
+    options.release.set(targetJavaVersion)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    compilerOptions.jvmTarget.set(JvmTarget.fromTarget(targetJavaVersion.toString()))
+}
+
+tasks.jar {
+    from("LICENSE") {
+        rename { "${it}_${project.base.archivesName}" }
+    }
+}
+
+// configure the maven publication
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            artifactId = project.property("archives_base_name") as String
+            from(components["java"])
+        }
+    }
+
+    // See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
+    repositories {
+        // Add repositories to publish to here.
+        // Notice: This block does NOT have the same function as the block in the top level.
+        // The repositories here will be used for publishing your artifact, not for
+        // retrieving dependencies.
+    }
+}

--- a/jamcraft/gradle.properties
+++ b/jamcraft/gradle.properties
@@ -1,0 +1,15 @@
+# Done to increase the memory available to gradle.
+org.gradle.jvmargs=-Xmx1G
+# Fabric Properties
+# check these on https://modmuss50.me/fabric.html
+minecraft_version=1.21.1
+yarn_mappings=1.21.1+build.3
+loader_version=0.16.5
+kotlin_loader_version=1.12.1+kotlin.2.0.20
+# Mod Properties
+mod_version=1.0-SNAPSHOT
+maven_group=me.browserjam
+archives_base_name=jamcraft
+# Dependencies
+# check this on https://modmuss50.me/fabric.html
+fabric_version=0.104.0+1.21.1

--- a/jamcraft/gradle/wrapper/gradle-wrapper.properties
+++ b/jamcraft/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,1 @@
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip

--- a/jamcraft/settings.gradle.kts
+++ b/jamcraft/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        maven("https://maven.fabricmc.net/") {
+            name = "Fabric"
+        }
+        gradlePluginPortal()
+    }
+}

--- a/jamcraft/src/client/kotlin/me/browserjam/jamcraft/client/JamcraftClient.kt
+++ b/jamcraft/src/client/kotlin/me/browserjam/jamcraft/client/JamcraftClient.kt
@@ -1,0 +1,9 @@
+package me.browserjam.jamcraft.client
+
+import net.fabricmc.api.ClientModInitializer
+
+class JamcraftClient : ClientModInitializer {
+
+    override fun onInitializeClient() {
+    }
+}

--- a/jamcraft/src/client/resources/jamcraft.client.mixins.json
+++ b/jamcraft/src/client/resources/jamcraft.client.mixins.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "me.browserjam.jamcraft.mixin.client",
+  "compatibilityLevel": "JAVA_21",
+  "client": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/jamcraft/src/main/kotlin/me/browserjam/jamcraft/HTMLRenderer.kt
+++ b/jamcraft/src/main/kotlin/me/browserjam/jamcraft/HTMLRenderer.kt
@@ -1,0 +1,541 @@
+package me.browserjam.jamcraft
+
+import net.fabricmc.loader.impl.util.log.Log
+import net.fabricmc.loader.impl.util.log.LogCategory
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Node
+import org.jsoup.nodes.TextNode
+import java.awt.Color
+import java.awt.Font
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
+import kotlin.math.max
+
+
+data class DOMRect(
+    var x: Int, var y: Int,
+    var width: Int,
+    var height: Int
+) {
+    override fun toString(): String {
+        return "{x=$x; y=$y; width=$width; height=$height}"
+    }
+}
+
+/** TODO: DO NOT RELY ON ANYTHING BESIDES `rects`. Have to re-do the whole "making the biggest rectangle" */
+interface Layout {
+    var blockX: Int
+    var blockY: Int
+    var blockWidth: Int
+    var blockHeight: Int
+    val rects: List<DOMRect>
+
+    companion object {
+        fun fromRect(rect: DOMRect): Layout {
+            return object : Layout {
+                override var blockX = rect.x
+                override var blockY = rect.y
+                override var blockWidth = rect.width
+                override var blockHeight = rect.height
+                override val rects = mutableListOf(rect)
+            }
+        }
+
+        fun fromRects(rects: List<DOMRect>): Layout {
+            var minX = Int.MAX_VALUE
+            var minY = Int.MAX_VALUE
+            var maxWidth = 0
+            var maxHeight = 0
+
+            // Some rects don't overlap, and this would misrepresent the height.
+            // TODO: rework
+            for (r in rects) {
+                if (r.x < minX) minX = r.x
+                if (r.y < minY) minY = r.y
+
+                if (r.width > maxWidth) maxWidth = r.width
+                if (r.height > maxHeight) maxHeight = r.height
+            }
+
+            return object : Layout {
+                override var blockX = minX
+                override var blockY = minY
+                override var blockWidth = maxWidth
+                override var blockHeight = maxHeight
+                override val rects = rects
+            }
+        }
+    }
+}
+
+enum class Trim {
+    None,
+    Beginning,
+    End,
+}
+data class StyleCascade(
+    val color: Color,
+    val font: Font,
+    val textUnderline: Boolean,
+    val trim: Trim
+) {
+    fun clone(newColor: Color? = null, newFont: Font? = null, underline: Boolean? = null, newTrim: Trim? = null): StyleCascade {
+        return StyleCascade(newColor ?: color, newFont ?: font, underline ?: textUnderline, newTrim ?: trim)
+    }
+
+    companion object {
+        val default = StyleCascade(
+            Color.BLACK,
+            Font(Font.SERIF, Font.PLAIN, 16),
+            false,
+            Trim.None
+        )
+    }
+
+}
+
+interface View {
+    var buffer: BufferedImage
+    var style: StyleCascade?
+    fun render(
+        x: Int = 0,
+        y: Int = 0,
+        maxWidth: Int = buffer.width,
+        maxHeight: Int = buffer.height,
+        initialX: Int = x
+    ): Layout
+}
+
+class EmptyView(override var buffer: BufferedImage): View {
+    override var style: StyleCascade? = null
+    override fun render(x: Int, y: Int, maxWidth: Int, maxHeight: Int, initialX: Int): Layout {
+        return object : Layout {
+            override var blockX = x
+            override var blockY = y
+            override var blockWidth = 0
+            override var blockHeight = 0
+            override val rects = listOf(
+                DOMRect(
+                    x, y, 0, 0
+                )
+            )
+        }
+    }
+}
+
+class BlockView(override var buffer: BufferedImage, var tagName: String = "?") : View {
+    val children = mutableListOf<View>()
+    override var style: StyleCascade? = null
+
+    override fun toString(): String {
+        return "{ ${children.joinToString("; ")} }"
+    }
+
+    var marginLeft = 0
+    var marginTop = 0
+    var marginRight = 0
+    var marginBottom = 0
+    override fun render(x: Int, y: Int, maxWidth: Int, maxHeight: Int, initialX: Int): Layout {
+        var realX = x + marginLeft
+        var realY = y + marginTop
+        var realMaxWidth = maxWidth - marginRight
+        var realMaxHeight = maxHeight - marginBottom
+
+        var currentX = realX
+        var currentY = realY
+        var currentMaxHeight = realMaxHeight
+
+        var actualHeight = marginTop + marginBottom
+
+        var contentHeight = 0
+
+        // MARGIN COLLAPSE 😭
+        if (children.isEmpty()) actualHeight = max(marginTop, marginBottom)
+
+        println("<$tagName> bounds: ($realX, $realY) : {$realMaxWidth, $realMaxHeight} $this")
+        println("buf: ${buffer.width}, ${buffer.height}")
+
+        /** Represents all the "bottoms" (x + height)s of the children, to select the highest one */
+        val bottoms = mutableListOf<Int>()
+
+        /** margin collapse */
+        var previousMarginBottom = 0
+
+        for ((i, view) in children.withIndex()) {
+            if (view.style == null) {
+                view.style = this.style
+
+                if (i == 0) {
+                    view.style = view.style?.clone(newTrim = Trim.Beginning)
+                }
+                if (i == children.size - 1) {
+                    view.style = view.style?.clone(newTrim = Trim.End)
+                }
+            }
+
+            if (view is BlockView) {
+                currentY = realY + contentHeight
+                currentX = realX
+
+                println("<$tagName> / <${view.tagName}>: margin collapse: ${view.marginTop - previousMarginBottom} = ${view.marginTop} - $previousMarginBottom")
+                view.marginTop = max(view.marginTop - previousMarginBottom, 0)
+                previousMarginBottom = view.marginBottom
+            } else {
+                previousMarginBottom = 0
+            }
+            Log.info(LogCategory.LOG, "doing child $i of $tagName")
+            val layout = view.render(realX, currentY, realMaxWidth, currentMaxHeight, currentX)
+            val lastRect = layout.rects.last()
+            bottoms.add((lastRect.y + lastRect.height) - realY)
+            contentHeight = bottoms.maxOrNull() ?: 0
+            println("<$tagName>: contentHeight=$contentHeight, (${lastRect.y} + ${lastRect.height}) - $realY, $bottoms")
+            if (view is BlockView) {
+                currentY = realY + contentHeight
+                currentX = realX
+            } else {
+                currentX = lastRect.x + lastRect.width
+                currentY = lastRect.y
+            }
+            currentMaxHeight = realMaxHeight - contentHeight
+            actualHeight = marginTop + contentHeight + marginBottom
+        }
+
+        return Layout.fromRect(
+            DOMRect(
+                x, y, maxWidth, actualHeight
+            )
+        )
+    }
+}
+
+class TextNodeView(override var buffer: BufferedImage, var content: String) : View {
+    override fun toString(): String {
+        return "($content)"
+    }
+
+    override var style: StyleCascade? = null
+    override fun render(x: Int, y: Int, maxWidth: Int, maxHeight: Int, initialX: Int): Layout {
+        println("textNode ($content) bounds: ($x, $y), initialX: $initialX : {$maxWidth, $maxHeight} $this")
+        val graphics = buffer.createGraphics()
+
+        val style = this.style ?: StyleCascade.default
+        graphics.color = style.color
+        graphics.font = style.font
+        val fm = graphics.fontMetrics
+
+        if (style.trim == Trim.Beginning) {
+            content = content.trimStart()
+        }
+        if (style.trim == Trim.End) {
+            content = content.trimEnd()
+        }
+
+        val actualLines = wrap(content, fm, maxWidth, initalMaxWidth = max(maxWidth - initialX, 0))
+
+        println("($content) Wrapped: $actualLines")
+
+        graphics.setRenderingHint(
+            RenderingHints.KEY_TEXT_ANTIALIASING,
+            RenderingHints.VALUE_TEXT_ANTIALIAS_ON
+        );
+
+        val height = fm.maxAscent
+        var rects: List<DOMRect> = actualLines.mapIndexed { index, oldStr ->
+            val str = oldStr.replace("\t", "    ")
+            // Uhhhhhh that's a huge ass hack that is super weird
+
+            val width = fm.stringWidth(str)
+            if (WebRendererFlags.displayTextBounds) {
+                graphics.color = Color.ORANGE
+                graphics.drawRect(if (index == 0) initialX else x, y, width, height)
+            }
+            graphics.color = style.color
+            graphics.drawString(str, if (index == 0) initialX else x, (y + height * index) + fm.maxAscent)
+            println("Draw string at ${if (index == 0) initialX else x}, ${(y + height * index)}")
+            if (style.textUnderline) {
+                graphics.fillRect(if (index == 0) initialX else x, (y + height * index) + fm.maxAscent, width, 1)
+            }
+
+            DOMRect(if (index == 0) initialX else x, y + height * index, width, height)
+        }
+
+        if (rects.isEmpty()) {
+            rects = listOf(DOMRect(x, y, 0, 0))
+        }
+        println("($content) $rects")
+        return Layout.fromRects(rects)
+    }
+}
+
+class InlineView(override var buffer: BufferedImage, var tagName: String = "?") : View {
+    override var style: StyleCascade? = null
+
+    val children = mutableListOf<View>()
+
+    override fun toString(): String {
+        return "( ${children.joinToString("; ")} )"
+    }
+
+    override fun render(x: Int, y: Int, maxWidth: Int, maxHeight: Int, initialX: Int): Layout {
+        var currentX = initialX
+        var currentY = y
+        var currentMaxHeight = maxHeight
+
+        var contentHeight = 0
+        var contentWidth = 0
+
+        println("inline <$tagName> bounds: ($x, $y) : {$maxWidth, $maxHeight} $this")
+        println("buf: ${buffer.width}, ${buffer.height}")
+
+        /** Represents all the "bottoms" (x + height)s of the children, to select the highest one */
+        val bottoms = mutableListOf<Int>()
+
+        /** margin collapse */
+        var previousMarginBottom = 0
+
+        val domRects = mutableListOf<DOMRect>()
+        for ((i, view) in children.withIndex()) {
+            if (view.style == null) {
+                view.style = this.style
+            }
+
+            if (view is BlockView) {
+                currentY = y + contentHeight
+                currentX = x
+
+                println("inline <$tagName> / <${view.tagName}>: margin collapse: ${view.marginTop - previousMarginBottom} = ${view.marginTop} - $previousMarginBottom")
+                view.marginTop = max(view.marginTop - previousMarginBottom, 0)
+                previousMarginBottom = view.marginBottom
+            } else {
+                previousMarginBottom = 0
+            }
+            Log.info(LogCategory.LOG, "doing child $i of inline $tagName")
+            val layout = view.render(x, currentY, maxWidth, currentMaxHeight, currentX)
+            val spaceWidth = buffer.graphics.fontMetrics.stringWidth(" ")
+            val lastRect = layout.rects.last()
+            bottoms.add((lastRect.y + lastRect.height) - y)
+            contentHeight = bottoms.maxOrNull() ?: 0
+            if (view is BlockView) {
+                currentY = y + contentHeight
+                currentX = x + spaceWidth
+            } else {
+                currentX = lastRect.x + lastRect.width + spaceWidth
+                currentY = lastRect.y
+            }
+            currentMaxHeight = maxHeight - contentHeight
+            domRects.addAll(layout.rects)
+            println("Adding rectangles to $tagName: ${layout.rects}")
+        }
+
+        if (domRects.isEmpty()) {
+            domRects.add(DOMRect(x, y, 0, 0))
+        }
+
+        println("Final layout of $tagName: ${Layout.fromRects(domRects).blockHeight}")
+        return Layout.fromRects(domRects)
+    }
+}
+
+fun em2px(emUnits: Double, font: Font): Int {
+    return (font.size.toDouble() * emUnits).toInt()
+}
+
+fun body(buffer: BufferedImage, children: MutableList<View>, style: StyleCascade = StyleCascade.default): BlockView {
+    val view = BlockView(buffer, "body")
+    view.marginLeft = 8
+    view.marginBottom = 8
+    view.marginRight = 8
+    view.marginTop = 8
+    view.children.addAll(children)
+    view.style = style
+
+    return view
+}
+
+val hMargins = arrayOf(.67, .75, .83, 1.0, 1.5, 1.67)
+val hFontSizeMultipliers = arrayOf(2.0, 1.5, 1.17, 1.0, .83, .75)
+fun h(
+    number: Int,
+    buffer: BufferedImage,
+    children: MutableList<View>,
+    style: StyleCascade = StyleCascade.default
+): BlockView {
+    val view = BlockView(buffer, "h$number")
+    val realFont = Font(
+        style.font.fontName,
+        style.font.style or Font.BOLD,
+        em2px(hFontSizeMultipliers[number], style.font)
+    )
+    val margin = em2px(hMargins[number], realFont)
+
+    view.marginBottom = margin
+    view.marginTop = margin
+    view.children.addAll(children)
+    view.style = style.clone(newFont = realFont)
+
+    return view
+}
+
+fun p(buffer: BufferedImage, children: MutableList<View>, style: StyleCascade = StyleCascade.default): BlockView {
+    val view = BlockView(buffer, "p")
+    val margin = em2px(1.0, style.font)
+
+    view.marginBottom = margin
+    view.marginTop = margin
+    view.children.addAll(children)
+    view.style = style
+
+    return view
+}
+
+fun dl(buffer: BufferedImage, children: MutableList<View>, style: StyleCascade = StyleCascade.default): BlockView {
+    val view = BlockView(buffer, "dl")
+    val margin = em2px(1.0, style.font)
+
+    view.marginBottom = margin
+    view.marginTop = margin
+    view.children.addAll(children)
+    view.style = style
+
+    return view
+}
+
+fun dt(buffer: BufferedImage, children: MutableList<View>, style: StyleCascade = StyleCascade.default): BlockView {
+    val view = BlockView(buffer, "dt")
+
+    view.children.addAll(children)
+    view.style = style
+
+    return view
+}
+
+fun dd(buffer: BufferedImage, children: MutableList<View>, style: StyleCascade = StyleCascade.default): BlockView {
+    val view = BlockView(buffer, "dd")
+    val margin = em2px(1.0, style.font)
+
+    view.marginLeft = margin
+    view.children.addAll(children)
+    view.style = style
+
+    return view
+}
+
+fun simpleBlock(buffer: BufferedImage, children: MutableList<View>, style: StyleCascade = StyleCascade.default): BlockView {
+    val view = BlockView(buffer, "?block?")
+
+    view.children.addAll(children)
+    view.style = style
+
+    return view
+}
+
+fun blockquote(buffer: BufferedImage, children: MutableList<View>, style: StyleCascade = StyleCascade.default): BlockView {
+    val view = BlockView(buffer, "blockquote")
+
+    view.marginTop = em2px(1.0, style.font)
+    view.marginBottom = em2px(1.0, style.font)
+    view.marginLeft = 40
+    view.marginRight = 40
+    view.children.addAll(children)
+    view.style = style
+
+    return view
+}
+
+fun pre(buffer: BufferedImage, children: MutableList<View>, style: StyleCascade = StyleCascade.default): BlockView {
+    val view = BlockView(buffer, "pre/xmp")
+
+    view.marginTop = em2px(1.0, style.font)
+    view.marginBottom = em2px(1.0, style.font)
+    view.children.addAll(children)
+    view.style = style.clone(newFont = Font(Font.MONOSPACED, style.font.style, style.font.size))
+
+    return view
+}
+
+fun ulOl(buffer: BufferedImage, children: MutableList<View>, style: StyleCascade = StyleCascade.default): BlockView {
+    val view = BlockView(buffer, "ul/ol")
+
+    view.marginTop = em2px(1.0, style.font)
+    view.marginBottom = em2px(1.0, style.font)
+    view.marginLeft = 40
+    view.children.addAll(children)
+    view.style = style
+
+    return view
+}
+
+fun empty(buffer: BufferedImage): View {
+    return EmptyView(buffer)
+}
+
+fun unknownElement(
+    buffer: BufferedImage,
+    children: MutableList<View>,
+    tg: String = "?",
+    style: StyleCascade = StyleCascade.default
+): InlineView {
+    val view = InlineView(buffer, tg)
+
+    view.children.addAll(children)
+    view.style = style
+
+    return view
+}
+
+fun a(buffer: BufferedImage, children: MutableList<View>, style: StyleCascade = StyleCascade.default): InlineView {
+    val view = InlineView(buffer, "a")
+
+    view.children.addAll(children)
+    view.style = style.clone(underline = true, newColor = Color.BLUE)
+
+    return view
+}
+
+fun nodeToView(buffer: BufferedImage, node: Node, pre: Boolean = false): View {
+    if (node is Element) {
+        return elementToView(buffer, node)
+    }
+    if (node is TextNode) {
+        println("Creating view from text node ${if (node.text().contains('\n')) "[has \\n] " else ""}(${node.text()})")
+        return TextNodeView(buffer, if (pre) node.wholeText else node.text())
+    }
+    return TextNodeView(buffer, "")
+}
+
+fun elementToView(buffer: BufferedImage, node: Element): View {
+    // TODO: move this out of here and into the TextNodeView renderer
+    val pre = node.tag().name == "pre" || node.tag().name == "xmp"
+
+    println("Creating view for <${node.tag().name}>")
+    val children = node.childNodes().map { nodeToView(buffer, it, pre) }.toMutableList()
+
+    if (node.tag().name.startsWith("h") && node.tag().name.length == 2) {
+        try {
+            val hn = node.tag().name.substring(1, 2).toInt()
+            println("Sliced hn to $hn")
+            if (hn < 7) {
+                return h(hn, buffer, children)
+            }
+        } catch (_: Throwable) {
+        }
+    }
+
+    when (node.tag().name) {
+        "title" -> return empty(buffer)
+        "body" -> return body(buffer, children)
+        "p" -> return p(buffer, children)
+        "dl" -> return dl(buffer, children)
+        "dt" -> return dt(buffer, children)
+        "dd" -> return dd(buffer, children)
+        "a" -> return a(buffer, children)
+        "blockquote" -> return blockquote(buffer, children)
+        "article", "aside", "footer", "header", "hgroup", "main", "li",
+        "nav", "section", "address", "figcaption", "div", "legend", "fieldset" ->
+            return simpleBlock(buffer, children)
+        "ul", "ol" -> return ulOl(buffer, children)
+        "pre", "xmp", "plaintext", "listing" -> return pre(buffer, children)
+    }
+
+    return unknownElement(buffer, children, node.tag().name)
+}

--- a/jamcraft/src/main/kotlin/me/browserjam/jamcraft/Jamcraft.kt
+++ b/jamcraft/src/main/kotlin/me/browserjam/jamcraft/Jamcraft.kt
@@ -1,0 +1,93 @@
+package me.browserjam.jamcraft
+
+import com.google.common.collect.ImmutableMap
+import com.mojang.brigadier.arguments.IntegerArgumentType
+import com.mojang.brigadier.arguments.StringArgumentType
+import it.unimi.dsi.fastutil.objects.Reference2ObjectArrayMap
+import net.fabricmc.api.ModInitializer
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback
+import net.fabricmc.fabric.api.gamerule.v1.GameRuleFactory
+import net.fabricmc.fabric.api.gamerule.v1.GameRuleRegistry
+import net.minecraft.block.*
+import net.minecraft.command.argument.BlockPosArgumentType
+import net.minecraft.command.argument.PosArgument
+import net.minecraft.server.command.CommandManager
+import net.minecraft.text.Text
+import net.minecraft.util.math.BlockPos
+import net.minecraft.world.GameRules
+import net.minecraft.world.GameRules.BooleanRule
+import org.jsoup.Jsoup
+
+
+//val NOT_ENOUGH_ARGS = SimpleCommandExceptionType(Text.literal("Not enough arguments to /render"))
+
+var DISPLAY_TEXT_BOUNDS: GameRules.Key<BooleanRule>? = null
+
+class Jamcraft : ModInitializer {
+
+    override fun onInitialize() {
+        DISPLAY_TEXT_BOUNDS = GameRuleRegistry.register("jcDisplayTextBounds", GameRules.Category.MISC, GameRuleFactory.createBooleanRule(false))
+
+        CommandRegistrationCallback.EVENT.register { dispatcher, _, _ ->
+            dispatcher.register(
+                CommandManager.literal("render")
+                    .requires { source -> source.hasPermissionLevel(2) }
+                    .then(
+                        CommandManager.argument("position", BlockPosArgumentType.blockPos())
+                            .then(
+                                CommandManager.argument("url", StringArgumentType.string())
+                                    .then(
+                                        CommandManager.argument("width", IntegerArgumentType.integer())
+                                            .executes { context ->
+                                                try {
+
+                                                val url = context.getArgument("url", String::class.java)
+                                                val width = context.getArgument("width", Int::class.java)
+                                                val position = context.getArgument("position", PosArgument::class.java)
+
+                                                val blkpos = position.toAbsoluteBlockPos(context.source)
+
+                                                val height = (width.toDouble() * (9.0/16.0)).toInt()
+
+                                                val leftmost = blkpos.x
+                                                val topmost = blkpos.z
+                                                val rightmost = leftmost + width
+                                                val bottommost = topmost + height
+
+                                                val elevation = blkpos.y
+
+
+                                                /*for (i in 0..height) {
+                                                    context.source.server.commandManager.executeWithPrefix(
+                                                        context.source,
+                                                        "/fill ${blkpos.x} ${blkpos.y} ${blkpos.z + i} $rightmost ${blkpos.y + 1} ${blkpos.z + i} minecraft:white_concrete"
+                                                    )
+                                                }*/
+                                                val world = context.source.world
+
+                                                WebRendererFlags.loadFromWorld(world)
+
+                                                val renderer = WebRenderer(width, height)
+                                                // TODO: move out of main thread
+                                                val doc = Jsoup.connect(url).get()
+                                                val pixels = renderer.render(doc)
+
+                                                buildPixels(pixels, width, world, leftmost, elevation, topmost)
+
+                                                context.source.sendFeedback(
+                                                    { Text.literal("Hello! $url, $width, $position") },
+                                                    true
+                                                )
+                                                0
+                                                } catch (e: Throwable) {
+                                                    println("ERROR! $e")
+                                                    0
+                                                }
+                                            }
+                                    )
+                            )
+                    )
+            )
+        }
+    }
+}

--- a/jamcraft/src/main/kotlin/me/browserjam/jamcraft/PixelBlockBuilder.kt
+++ b/jamcraft/src/main/kotlin/me/browserjam/jamcraft/PixelBlockBuilder.kt
@@ -1,0 +1,166 @@
+package me.browserjam.jamcraft
+
+import net.minecraft.block.Blocks
+import net.minecraft.util.math.BlockPos
+import net.minecraft.world.World
+import java.awt.Color
+import kotlin.math.round
+
+// TODO: properly represent colors
+// now it misrepresents their saturation
+// and only accounts for luminosity;
+// the terracotta blocks are also often
+// desaturated rather than dark
+
+val monochrome = arrayOf(
+    Blocks.BLACK_CONCRETE,
+    Blocks.BLACK_WOOL,
+    Blocks.GRAY_CONCRETE,
+    Blocks.GRAY_WOOL,
+    Blocks.LIGHT_GRAY_CONCRETE,
+    Blocks.LIGHT_GRAY_WOOL,
+    Blocks.WHITE_CONCRETE,
+    Blocks.WHITE_CONCRETE,
+    Blocks.WHITE_WOOL,
+)
+
+val redHue = arrayOf(
+    Blocks.NETHER_BRICKS,
+    Blocks.RED_NETHER_BRICKS,
+    Blocks.NETHER_WART_BLOCK,
+    Blocks.RED_CONCRETE,
+    Blocks.RED_CONCRETE,
+    Blocks.RED_CONCRETE,
+    Blocks.RED_WOOL,
+)
+
+val orangeHue = arrayOf(
+    Blocks.BROWN_TERRACOTTA,
+    Blocks.BROWN_CONCRETE,
+    Blocks.ORANGE_TERRACOTTA,
+    Blocks.SMOOTH_RED_SANDSTONE,
+    Blocks.ORANGE_CONCRETE,
+    Blocks.ORANGE_CONCRETE,
+    Blocks.ORANGE_WOOL,
+)
+
+val yellowHue = arrayOf(
+    Blocks.YELLOW_TERRACOTTA,
+    Blocks.YELLOW_TERRACOTTA,
+    Blocks.YELLOW_CONCRETE,
+    Blocks.YELLOW_CONCRETE,
+    Blocks.YELLOW_WOOL,
+    Blocks.YELLOW_WOOL,
+    Blocks.GOLD_BLOCK,
+)
+
+val limeHue = arrayOf(
+    Blocks.GREEN_CONCRETE,
+    Blocks.LIME_TERRACOTTA,
+    Blocks.LIME_TERRACOTTA,
+    Blocks.LIME_CONCRETE,
+    Blocks.LIME_CONCRETE,
+    Blocks.LIME_WOOL,
+)
+
+val greenHue = arrayOf(
+    Blocks.GREEN_TERRACOTTA,
+    Blocks.GREEN_CONCRETE,
+    Blocks.GREEN_CONCRETE,
+    Blocks.GREEN_CONCRETE,
+    Blocks.LIME_TERRACOTTA,
+    Blocks.LIME_CONCRETE,
+    Blocks.LIME_WOOL,
+)
+
+val cyanHue = arrayOf(
+    Blocks.DARK_PRISMARINE,
+    Blocks.WARPED_PLANKS,
+    Blocks.CYAN_CONCRETE,
+    Blocks.CYAN_WOOL,
+    Blocks.STRIPPED_WARPED_HYPHAE,
+    Blocks.OXIDIZED_COPPER,
+    Blocks.PRISMARINE_BRICKS,
+    Blocks.DIAMOND_BLOCK
+)
+
+val lightblueHue = arrayOf(
+    Blocks.BLUE_CONCRETE,
+    Blocks.BLUE_WOOL,
+    Blocks.LAPIS_BLOCK,
+    Blocks.LIGHT_BLUE_CONCRETE,
+    Blocks.LIGHT_BLUE_CONCRETE,
+    Blocks.LIGHT_BLUE_WOOL,
+)
+
+/*val blueHue = arrayOf(
+    Blocks.BLUE_CONCRETE,
+    Blocks.BLUE_CONCRETE,
+    Blocks.BLUE_WOOL,
+    Blocks.BLUE_WOOL,
+    Blocks.BLUE_WOOL,
+    Blocks.LAPIS_BLOCK,
+    Blocks.LIGHT_BLUE_TERRACOTTA,
+)*/
+
+val purpleHue = arrayOf(
+    Blocks.OBSIDIAN,
+    Blocks.PURPLE_CONCRETE,
+    Blocks.PURPLE_CONCRETE,
+    Blocks.PURPLE_CONCRETE,
+    Blocks.PURPLE_WOOL,
+    Blocks.PURPLE_WOOL,
+    Blocks.PURPLE_WOOL,
+    Blocks.PURPLE_WOOL,
+    Blocks.PURPLE_WOOL,
+    Blocks.AMETHYST_BLOCK,
+    Blocks.AMETHYST_BLOCK,
+    Blocks.AMETHYST_BLOCK,
+    Blocks.PURPUR_BLOCK,
+    Blocks.PURPUR_BLOCK,
+    Blocks.PURPUR_BLOCK,
+)
+
+val magentaHue = arrayOf(
+    Blocks.CRIMSON_PLANKS,
+    Blocks.STRIPPED_CRIMSON_HYPHAE,
+    Blocks.MAGENTA_CONCRETE,
+    Blocks.MAGENTA_CONCRETE,
+    Blocks.MAGENTA_WOOL,
+)
+
+val hues = arrayOf(
+    redHue, orangeHue, yellowHue, limeHue, cyanHue,
+    lightblueHue, lightblueHue, /*blueHue,*/ purpleHue, magentaHue
+)
+const val BRIGHTNESS_THRESHOLD = 0.12f
+const val SATURATION_THRESHOLD = 0.25f
+
+fun buildPixels(pixels: IntArray, width: Int, world: World, leftmost: Int, elevation: Int, topmost: Int) {
+    for ((i, pxSigned) in pixels.withIndex()) {
+        val x = i % width
+        val y = i.floorDiv(width)
+
+        val px = pxSigned + 16777216 // idk whatever
+        val color = Color(px)
+
+        val hsb = Color.RGBtoHSB(color.red, color.green, color.blue, null)
+
+        var colors = monochrome
+
+        if (hsb[1] > SATURATION_THRESHOLD && hsb[2] > BRIGHTNESS_THRESHOLD) {
+            val colorIndex = round(hsb[0] * hues.size.toFloat() - 1f).toInt()
+            colors = hues[colorIndex]
+        }
+
+        val luminance = (0.299*color.red + 0.587*color.green + 0.114*color.blue)
+
+        val step = (255).floorDiv(colors.size - 1)
+        val index = (luminance / step).toInt()
+
+        world.setBlockState(
+            BlockPos(leftmost + x, elevation, topmost + y),
+            colors[index].defaultState
+        )
+    }
+}

--- a/jamcraft/src/main/kotlin/me/browserjam/jamcraft/Utils.kt
+++ b/jamcraft/src/main/kotlin/me/browserjam/jamcraft/Utils.kt
@@ -1,0 +1,165 @@
+package me.browserjam.jamcraft
+
+import net.minecraft.predicate.entity.DistancePredicate.y
+import java.awt.FontMetrics
+
+
+/**
+ * Globally available utility classes, mostly for string manipulation.
+ *
+ * @author Jim Menard, <a href="mailto:jimm@io.com">jimm@io.com</a>
+ * copied from https://stackoverflow.com/questions/12129633/how-do-i-render-wrapped-text-on-an-image-in-java
+ *
+ * TODO: use the Unicode UAX 14 algo (no time lol)
+ */
+
+
+fun wrap(str: String, fm: FontMetrics, maxWidth: Int, initalMaxWidth: Int = maxWidth): List<String> {
+    if (str.trim() == "") return listOf()
+
+    val lines = splitIntoLines(str)
+    if (lines.isEmpty()) return lines
+
+    val strings = ArrayList<String>()
+    val iter = lines.iterator()
+    while (iter.hasNext()) {
+        wrapLineInto(iter.next(), strings, fm, maxWidth, initalMaxWidth)
+    }
+    return strings
+}
+
+/**
+ * Given a line of text and font metrics information, wrap the line and add
+ * the new line(s) to <var>list</var>.
+ *
+ * @param tempLine
+ * a line of text
+ * @param list
+ * an output list of strings
+ * @param fm
+ * font metrics
+ * @param maxWidth
+ * maximum width of the line(s)
+ */
+fun wrapLineInto(tempLine: String, list: MutableList<String>, fm: FontMetrics, maxWidth: Int, initalMaxWidth: Int = maxWidth) {
+    if (maxWidth == 0) return
+
+    var line = tempLine
+    var len = line.length
+    var width: Int = 0
+    var currentMaxWidth = initalMaxWidth
+
+    while (len > 0 && (fm.stringWidth(line).also { width = it }) > currentMaxWidth) {
+        // Guess where to split the line. Look for the next space before
+        // or after the guess.
+        val guess = len * currentMaxWidth / width
+        var before = line.substring(0, guess)/*.trim { it.isWhitespace() || it < ' ' }*/
+
+        width = fm.stringWidth(before)
+        var pos = findBreakBefore(line, guess)
+        if (pos == -1) { // Too short or possibly just right
+            pos = findBreakAfter(line, guess)
+            println("found bre after $pos, $guess")
+            if (pos != -1) { // Make sure this doesn't make us too long
+                before = line.substring(0, pos)/*.trim { it.isWhitespace() || it < ' ' }*/
+                if (fm.stringWidth(before) > currentMaxWidth) pos = findBreakBefore(line, guess)
+            }
+        }
+        if (pos == -1) {
+            pos = if (width > currentMaxWidth)
+                guess // Split in the middle of the word
+            else
+                guess
+        }
+        println("Spliutting word ($line) in position $pos, w=$width, max=$currentMaxWidth,")
+
+
+        list.add(line.substring(0, pos)/*.trim { it.isWhitespace() || it < ' ' }*/)
+        line = line.substring(pos)/*.trim { it.isWhitespace() || it < ' ' }*/
+        len = line.length
+        currentMaxWidth = maxWidth // Once we added a line, it has now reset our "carriage"
+    }
+    if (len > 0) list.add(line)
+    return
+}
+
+/**
+ * Returns the index of the first whitespace character or '-' in <var>line</var>
+ * that is at or before <var>start</var>. Returns -1 if no such character is
+ * found.
+ *
+ * @param line
+ * a string
+ * @param start
+ * where to star looking
+ */
+fun findBreakBefore(line: String, start: Int): Int {
+    for (i in start downTo 0) {
+        val c = line[i]
+        if (Character.isWhitespace(c) || c == '-') return i
+    }
+    return -1
+}
+
+/**
+ * Returns the index of the first whitespace character or '-' in <var>line</var>
+ * that is at or after <var>start</var>. Returns -1 if no such character is
+ * found.
+ *
+ * @param line
+ * a string
+ * @param start
+ * where to star looking
+ */
+fun findBreakAfter(line: String, start: Int): Int {
+    val len = line.length
+    for (i in start until len) {
+        val c = line[i]
+        if (Character.isWhitespace(c) || c == '-') return i
+    }
+    return -1
+}
+
+/**
+ * Returns an array of strings, one for each line in the string. Lines end
+ * with any of cr, lf, or cr lf. A line ending at the end of the string will
+ * not output a further, empty string.
+ *
+ *
+ * This code assumes <var>str</var> is not `null`.
+ *
+ * @param str
+ * the string to split
+ * @return a non-empty list of strings
+ */
+fun splitIntoLines(str: String): List<String> {
+    val strings = ArrayList<String>()
+
+    val len = str.length
+    if (len == 0) {
+        strings.add("")
+        return strings
+    }
+
+    var lineStart = 0
+
+    var i = 0
+    while (i < len) {
+        val c = str[i]
+        if (c == '\r') {
+            var newlineLength = 1
+            if ((i + 1) < len && str[i + 1] == '\n') newlineLength = 2
+            strings.add(str.substring(lineStart, i))
+            lineStart = i + newlineLength
+            if (newlineLength == 2)  // skip \n next time through loop
+                ++i
+        } else if (c == '\n') {
+            strings.add(str.substring(lineStart, i))
+            lineStart = i + 1
+        }
+        ++i
+    }
+    if (lineStart < len) strings.add(str.substring(lineStart))
+
+    return strings
+}

--- a/jamcraft/src/main/kotlin/me/browserjam/jamcraft/WebRenderer.kt
+++ b/jamcraft/src/main/kotlin/me/browserjam/jamcraft/WebRenderer.kt
@@ -1,0 +1,47 @@
+package me.browserjam.jamcraft
+
+import net.minecraft.world.World
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import java.awt.*
+import java.awt.image.BufferedImage
+import java.awt.image.DataBufferInt
+import java.io.File
+import javax.imageio.ImageIO
+
+object WebRendererFlags {
+    var displayTextBounds = false
+
+    fun loadFromWorld(world: World) {
+        displayTextBounds = world.gameRules.getBoolean(DISPLAY_TEXT_BOUNDS)
+    }
+}
+
+class WebRenderer(width: Int, height: Int) {
+    val buffer = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+    val graphics: Graphics2D = buffer.createGraphics()
+
+    init {
+        graphics.color = Color.WHITE
+        graphics.fillRect(0, 0, width, height)
+    }
+
+    fun render(doc: Document): IntArray {
+        val b = doc.body()
+
+        val rootNode = elementToView(buffer, b)
+
+        try {
+            rootNode.render()
+        } catch (e: Throwable) {
+            println("Err: ${e.stackTraceToString()}")
+        }
+
+        val buf2 = BufferedImage(buffer.width, buffer.height, BufferedImage.TYPE_INT_RGB)
+        buffer.copyData(buf2.raster)
+        val fl = File("./render.png")
+        ImageIO.write(buf2, "png", fl)
+
+        return (buffer.data.dataBuffer as DataBufferInt).data
+    }
+}

--- a/jamcraft/src/main/resources/fabric.mod.json
+++ b/jamcraft/src/main/resources/fabric.mod.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "id": "jamcraft",
+  "version": "${version}",
+  "name": "jamcraft",
+  "description": "",
+  "authors": [],
+  "contact": {},
+  "license": "All-Rights-Reserved",
+  "icon": "assets/jamcraft/icon.png",
+  "environment": "*",
+  "entrypoints": {
+    "client": [
+      "me.browserjam.jamcraft.client.JamcraftClient"
+    ],
+    "main": [
+      "me.browserjam.jamcraft.Jamcraft"
+    ]
+  },
+  "mixins": [
+    "jamcraft.mixins.json",
+    {
+      "config": "jamcraft.client.mixins.json",
+      "environment": "client"
+    }
+  ],
+  "depends": {
+    "fabricloader": ">=${loader_version}",
+    "fabric-language-kotlin": ">=${kotlin_loader_version}",
+    "fabric": "*",
+    "minecraft": "${minecraft_version}"
+  }
+}

--- a/jamcraft/src/main/resources/jamcraft.mixins.json
+++ b/jamcraft/src/main/resources/jamcraft.mixins.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "me.browserjam.jamcraft.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
To quote one of the creators of the jam:
![pic](https://github.com/user-attachments/assets/ddf35b74-7f45-4082-80bd-2d5e9340f884)
> some such graphical context

And a graphical context i found.
Who needs any "windows", "images", or "canvases", we have **_Minecraft_**.

This is a fabric mod that allows you to enter a command `/render <position> <url> <width>`, that will fetch the url (from the main thread btw, sorry), and fill the space (top-left corner being `<position>`) with the blocks corresponding to the rendered HTML. The aspect ratio is hardcoded to be 16/9.

This is my first time creating a minecraft mod and a second time working with Kotlin, so the code might be stupid. (It most definitely is) Also it uses a library for parsing HTML (ik lame) because otherwise I would not have finished this at all.

It is semi-compliant with some web standards, that is to say it doesn't even have list support 😭
But it's able to support like all colors with different blocks, even though that's not used anywhere, and also the text is anti-aliased - with minecraft blocks...

Anyway, here's my abomination, and unfortunately I didn't have time for any interactivity, so it's just static for now.


P.S. Also this thing will create a mess of your logs and will also create a png, to which it also renders the HTML, I didn't have time to clean that up, sorry lol

Demo:
![sorry sir, you've got some villages on your website](https://github.com/user-attachments/assets/7234d585-4da1-402b-9bcd-2c1357b8f65b)
