### PR TITLE
Update readme to mention supporting ladybird as a browser

### DIFF
--- a/mbkv/README.md
+++ b/mbkv/README.md
@@ -9,7 +9,7 @@ What's a browser without some dead memes?
 * install bun
 * `bun install && bun start`
 * visit everyone's favorite new browser ladybird and connect to http://localhost:3000
-* alternatively visit https://browser.mbkv.io with ladybird using the linux option `--enable-qt-networking`, unclear why ladybird's request code fails to load
+* alternatively visit https://browser.mbkv.io with ladybird
 
 Of course this works with other browsers as well
 


### PR DESCRIPTION
It's fixed now! Thanks to CxByte on discord for troubleshooting it. The issue was my DNS was configured to use ipv6 but nginx wasn't actually running ipv6. I removed ipv6 from the dns settings temporarily and I'll figure out the nginx config later on

I checked 1.1.1.1, and 8.8.8.8 and both seemed to have refreshed, but the DNS settings may be cached regionly for about another day.